### PR TITLE
Added .gitignore for build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/*build*
+*.user


### PR DESCRIPTION
The wildcard on the build directory is because I use `build` for builds made from command line and `buildqtc` from QtCreator IDE, so it covers other cases. The other is because I (unfortunately barely) remember there was other user files other than for CMake from QtC.
If there is some reason to make them explicit instead let me know.