### PR TITLE
Don't force the build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(arqiver)
-set(CMAKE_BUILD_TYPE Release)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 add_definitions(-Wall)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)


### PR DESCRIPTION
just set it if wasn't set in command line,
this way another developer can set it to Debug and do her/his checks without the need to modify the CMake code.